### PR TITLE
支持 OPPO 开发者工具

### DIFF
--- a/build-runtime.js
+++ b/build-runtime.js
@@ -111,7 +111,8 @@ function onBeforeBuildFinish(event, options) {
 }
 
 module.exports = {
-    name: 'Runtime',
+    name: 'OPPO 快游戏',
+    platform: 'runtime',
     extends: Editor.isWin32 ? 'win32' : 'mac',
     messages: {
         'build-finished': onBeforeBuildFinish,

--- a/build-runtime.js
+++ b/build-runtime.js
@@ -114,7 +114,14 @@ module.exports = {
     name: 'OPPO 快游戏',
     platform: 'runtime',
     extends: Editor.isWin32 ? 'win32' : 'mac',
+    buttons: [
+        Editor.Builder.DefaultButtons.Build,
+        { label: Editor.T('BUILDER.play'), message: 'play' },
+    ],
     messages: {
         'build-finished': onBeforeBuildFinish,
+        'play' (event, options) {
+            Editor.Ipc.sendToMain('oppo-runtime-devtools:open', options);
+        },
     },
 };


### PR DESCRIPTION
 - 将原先的 Runtime 拆分成两个字段，允许随意重命名
 - 移除了构建面板中的编译按钮
 - 在构建面板中点击运行时，唤起 OPPO 开发者工具

依赖 Creator 2.0.0 beta.2，否则无法正常打包。